### PR TITLE
dashboard 컴포넌트 라우팅에 따른 분리 및 react-router-dom 설정하기

### DIFF
--- a/client/src/component/dashboard/Dashboard.js
+++ b/client/src/component/dashboard/Dashboard.js
@@ -1,112 +1,21 @@
 import React, {useState} from 'react';
 import clsx from 'clsx';
-import { makeStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Drawer from '@material-ui/core/Drawer';
-import Box from '@material-ui/core/Box';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
 import List from '@material-ui/core/List';
-import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import IconButton from '@material-ui/core/IconButton';
-import Badge from '@material-ui/core/Badge';
-import Container from '@material-ui/core/Container';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import MenuIcon from '@material-ui/icons/Menu';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import NotificationsIcon from '@material-ui/icons/Notifications';
 import { mainListItems, secondaryListItems } from './listItems';
-import Chart from './Chart';
-import Deposits from './Deposits';
-import Orders from './Orders';
-import Copyright from './Copyright'
-
-// Route
-import { Route } from 'react-router-dom';
 
 
-const drawerWidth = 240;
+import {Route} from 'react-router-dom'
+import Main from './Main';
+import Payroll from '../employee/Payroll'
+import useStyles from './DashboardStyle'
+import Header from './Header'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-  },
-  toolbar: {
-    paddingRight: 24, // keep right padding when drawer closed
-  },
-  toolbarIcon: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-  },
-  appBar: {
-    zIndex: theme.zIndex.drawer + 1,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  appBarShift: {
-    marginLeft: drawerWidth,
-    width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  menuButton: {
-    marginRight: 36,
-  },
-  menuButtonHidden: {
-    display: 'none',
-  },
-  title: {
-    flexGrow: 1,
-  },
-  drawerPaper: {
-    position: 'relative',
-    whiteSpace: 'nowrap',
-    width: drawerWidth,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  drawerPaperClose: {
-    overflowX: 'hidden',
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    width: theme.spacing(7),
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing(9),
-    },
-  },
-  appBarSpacer: theme.mixins.toolbar,
-  content: {
-    flexGrow: 1,
-    height: '100vh',
-    overflow: 'auto',
-  },
-  container: {
-    paddingTop: theme.spacing(4),
-    paddingBottom: theme.spacing(4),
-  },
-  paper: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    overflow: 'auto',
-    flexDirection: 'column',
-  },
-  fixedHeight: {
-    height: 240,
-  },
-}));
+
 
 const Dashboard = () => {
     const classes = useStyles();
@@ -122,27 +31,7 @@ const Dashboard = () => {
     return (
       <div className={classes.root}>
         <CssBaseline />
-        <AppBar position="absolute" className={clsx(classes.appBar, open && classes.appBarShift)}>
-          <Toolbar className={classes.toolbar}>
-            <IconButton
-              edge="start"
-              color="inherit"
-              aria-label="open drawer"
-              onClick={handleDrawerOpen}
-              className={clsx(classes.menuButton, open && classes.menuButtonHidden)}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography component="h1" variant="h6" color="inherit" noWrap className={classes.title}>
-              Payroll Management System
-            </Typography>
-            <IconButton color="inherit">
-              <Badge badgeContent={4} color="secondary">
-                <NotificationsIcon />
-              </Badge>
-            </IconButton>
-          </Toolbar>
-        </AppBar>
+        <Header open={open} classes={classes} handleDrawerOpen={handleDrawerOpen}  />
         <Drawer
           variant="permanent"
           classes={{
@@ -162,31 +51,8 @@ const Dashboard = () => {
         </Drawer>
         <main className={classes.content}>
           <div className={classes.appBarSpacer} />
-          <Container maxWidth="lg" className={classes.container}>
-            <Grid container spacing={3}>
-              {/* Chart */}
-              <Grid item xs={12} md={8} lg={9}>
-                <Paper className={fixedHeightPaper}>
-                  <Chart />
-                </Paper>
-              </Grid>
-              {/* Recent Deposits */}
-              <Grid item xs={12} md={4} lg={3}>
-                <Paper className={fixedHeightPaper}>
-                  <Deposits />
-                </Paper>
-              </Grid>
-              {/* Recent Orders */}
-              <Grid item xs={12}>
-                <Paper className={classes.paper}>
-                  <Orders />
-                </Paper>
-              </Grid>
-            </Grid>
-            <Box pt={4}>
-              <Copyright />
-            </Box>
-          </Container>
+          <Route exact path="/" render={() => <Main fixedHeightPaper={fixedHeightPaper} />} />
+          <Route exact path="/payroll" component={Payroll} />
         </main>
       </div>
     );

--- a/client/src/component/dashboard/DashboardStyle.js
+++ b/client/src/component/dashboard/DashboardStyle.js
@@ -1,0 +1,83 @@
+import { makeStyles } from '@material-ui/core/styles';
+const drawerWidth = 240;
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+  toolbar: {
+    paddingRight: 24, // keep right padding when drawer closed
+  },
+  toolbarIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: '0 8px',
+    ...theme.mixins.toolbar,
+  },
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginRight: 36,
+  },
+  menuButtonHidden: {
+    display: 'none',
+  },
+  title: {
+    flexGrow: 1,
+  },
+  drawerPaper: {
+    position: 'relative',
+    whiteSpace: 'nowrap',
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  drawerPaperClose: {
+    overflowX: 'hidden',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    width: theme.spacing(7),
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing(9),
+    },
+  },
+  appBarSpacer: theme.mixins.toolbar,
+  content: {
+    flexGrow: 1,
+    height: '100vh',
+    overflow: 'auto',
+  },
+  fixedHeight: {
+    height: 240,
+  },
+  container: {
+    paddingTop: theme.spacing(4),
+    paddingBottom: theme.spacing(4),
+  },
+  paper: {
+    padding: theme.spacing(2),
+    display: 'flex',
+    overflow: 'auto',
+    flexDirection: 'column',
+  }
+}));
+
+export default useStyles

--- a/client/src/component/dashboard/Header.js
+++ b/client/src/component/dashboard/Header.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import clsx from 'clsx';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import Badge from '@material-ui/core/Badge';
+import MenuIcon from '@material-ui/icons/Menu';
+import NotificationsIcon from '@material-ui/icons/Notifications';
+
+
+const Header = ({open,classes, handleDrawerOpen})=>{
+    return (
+        <AppBar position="absolute" className={clsx(classes.appBar, open && classes.appBarShift)}>
+        <Toolbar className={classes.toolbar}>
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="open drawer"
+            onClick={handleDrawerOpen}
+            className={clsx(classes.menuButton, open && classes.menuButtonHidden)}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography component="h1" variant="h6" color="inherit" noWrap className={classes.title}>
+            Payroll Management System
+          </Typography>
+          <IconButton color="inherit">
+            <Badge badgeContent={4} color="secondary">
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+    )
+}
+
+export default Header

--- a/client/src/component/dashboard/Main.js
+++ b/client/src/component/dashboard/Main.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
+import Copyright from './Copyright';
+import Chart from './Chart';
+import Deposits from './Deposits';
+import Orders from './Orders';
+import useStyles from './DashboardStyle'
+
+const Main = ({fixedHeightPaper}) => {
+const classes = useStyles();
+ return (
+    <Container maxWidth="lg" className={classes.container}>
+    <Grid container spacing={3}>
+      {/* Chart */}
+      <Grid item xs={12} md={8} lg={9}>
+        <Paper className={fixedHeightPaper}>
+          <Chart />
+        </Paper>
+      </Grid>
+      {/* Recent Deposits */}
+      <Grid item xs={12} md={4} lg={3}>
+        <Paper className={fixedHeightPaper}>
+          <Deposits />
+        </Paper>
+      </Grid>
+      {/* Recent Orders */}
+      <Grid item xs={12}>
+        <Paper className={classes.paper}>
+          <Orders />
+        </Paper>
+      </Grid>
+    </Grid>
+    <Box pt={4}>
+      <Copyright />
+    </Box>
+  </Container>
+ )
+}
+
+
+export default Main

--- a/client/src/component/dashboard/listItems.js
+++ b/client/src/component/dashboard/listItems.js
@@ -11,8 +11,11 @@ import AssignmentIcon from '@material-ui/icons/Assignment';
 // import Link from '@material-ui/core/Link';
 import {Link} from 'react-router-dom'
 import '../../scss/listitem.scss'
+import Payroll from '../employee/Payroll'
 
 
+
+// JSX 형태로 단순 변수이다. return으로 값을 반환하지 않는다.
 export const mainListItems = (
   <div>
     <ListItem button>
@@ -24,7 +27,7 @@ export const mainListItems = (
     </Link>
     </ListItem>
     <ListItem button>
-    <Link className="nav-btn" color="inherit" to="/payroll">
+    <Link className="nav-btn" color="inherit" to="/payroll" >
       <ListItemIcon>
         <PeopleIcon />
       </ListItemIcon>
@@ -50,6 +53,8 @@ export const mainListItems = (
   </div>
 );
 
+
+// JSX 형태로 단순 변수이다. return으로 값을 반환하지 않는다.
 export const secondaryListItems = (
   <div>
     <ListSubheader inset>Saved reports</ListSubheader>

--- a/client/src/component/employee/Employee.js
+++ b/client/src/component/employee/Employee.js
@@ -1,2 +1,3 @@
 import React from 'react'
 
+

--- a/client/src/component/employee/Payroll.js
+++ b/client/src/component/employee/Payroll.js
@@ -1,2 +1,11 @@
 import React from 'react'
 
+const Payroll = () =>{
+    return (
+        <div>
+            Payroll
+        </div>
+    )
+}
+
+export default Payroll


### PR DESCRIPTION
react-router에서 핵심 개념은 결국 SPA에서 새로 고침 없이 페이지 전환을 하게끔 도와주는 것인데, 이 개념을 이해 못하면 <a>태그를 사용하던 시점에서 생각이 벗어나기 어렵다.

그리고 react-router-dom을 사용함에 따라 기존의 @material-ui 라이브러리 템플릿 코드의 구조를 많이 변경했다.